### PR TITLE
server: disable KT, TEE services, notifications and payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 🚧 Work in Progress 🚧
 
+Even in the `main` branch, resources from this repository are unstable in order to facilitate development.
+
+During development, several features will be disabled or insecurely implemented. Do not run this in production.
+
 # Flatline Server
 
 **Flatline Server** is a server prototype to which Signal-compatible clients can connect.

--- a/service/config/dev.yml
+++ b/service/config/dev.yml
@@ -43,6 +43,7 @@ metrics:
 tlsKeyStore:
   password: secret://tlsKeyStore.password
 
+# FLT(uoemai): All forms of payment are disabled in the prototype.
 stripe:
   apiKey: secret://stripe.apiKey
   idempotencyKeyGenerator: secret://stripe.idempotencyKeyGenerator
@@ -55,6 +56,7 @@ stripe:
     SEPA_DEBIT:
       - eur
 
+# FLT(uoemai): All forms of payment are disabled in the prototype.
 braintree:
   merchantId: unset
   publicKey: unset
@@ -75,12 +77,14 @@ braintree:
         "credential": "configuration"
       }
 
+# FLT(uoemai): All forms of payment are disabled in the prototype.
 googlePlayBilling:
   credentialsJson: secret://googlePlayBilling.credentialsJson
   packageName: package.name
   applicationName: test
   productIdToLevel: {}
 
+# FLT(uoemai): All forms of payment are disabled in the prototype.
 appleAppStore:
   env: SANDBOX
   bundleId: bundle.name
@@ -197,6 +201,7 @@ directoryV2:
     userAuthenticationTokenSharedSecret: secret://directoryV2.client.userAuthenticationTokenSharedSecret
     userIdTokenSharedSecret: secret://directoryV2.client.userIdTokenSharedSecret
 
+# Secure value recovery is disabled in the prototype.
 svr2:
   uri: svr2.example.com
   userAuthenticationTokenSharedSecret: secret://svr2.userAuthenticationTokenSharedSecret
@@ -241,14 +246,18 @@ tus:
   uploadUri: https://example.org/upload
   userAuthenticationTokenSharedSecret: secret://tus.userAuthenticationTokenSharedSecret
 
-apn: # Apple Push Notifications configuration
+# FLT(uoemai): Notification providers are replaced by a dummy logger during development.
+# Apple Push Notifications configuration
+apn:
   sandbox: true
   bundleId: com.example.textsecuregcm
   keyId: secret://apn.keyId
   teamId: secret://apn.teamId
   signingKey: secret://apn.signingKey
 
-fcm: # FCM configuration
+# FLT(uoemai): Notification providers are replaced by a dummy logger during development.
+# FCM configuration
+fcm:
   credentials: secret://fcm.credentials
 
 cdn:
@@ -405,6 +414,7 @@ registrationService:
   collationKeySalt: secret://registrationService.collationKeySalt
   registrationCaCertificate: irrelenvat # Uses insecure channel during development.
 
+# Key transparency is disabled in the prototype.
 keyTransparencyService:
   host: kt.example.com
   port: 443

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/DummySender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/DummySender.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Signal Messenger, LLC
+ * Copyright 2025 Molly Instant Messenger
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 package org.whispersystems.textsecuregcm.push;

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/DummySender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/DummySender.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package org.whispersystems.textsecuregcm.push;
+
+import io.dropwizard.lifecycle.Managed;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+public class DummySender implements Managed, PushNotificationSender {
+  private final String originalProvider;
+
+  public DummySender(String originalProvider) {
+    this.originalProvider = originalProvider;
+  }
+
+  @Override
+  public CompletableFuture<SendPushNotificationResult> sendNotification(final PushNotification notification) {
+    System.out.printf(
+        "Dummy notification sent: provider=%s, type=%s, urgent=%b, "
+            + "destination=%s, destinationDevice=%s, data=%s%n",
+        this.originalProvider,
+        notification.notificationType(),
+        notification.urgent(),
+        Objects.toString(notification.destination(), ""),
+        Objects.toString(notification.destinationDevice(), ""),
+        notification.data()
+    );
+
+    SendPushNotificationResult result =
+        new SendPushNotificationResult(true, null, false, null);
+
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public void start() {
+  }
+
+  @Override
+  public void stop() {
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
@@ -25,8 +25,8 @@ import org.whispersystems.textsecuregcm.util.Pair;
 public class PushNotificationManager {
 
   private final AccountsManager accountsManager;
-  private final APNSender apnSender;
-  private final FcmSender fcmSender;
+  private final PushNotificationSender apnSender;
+  private final PushNotificationSender fcmSender;
   private final PushNotificationScheduler pushNotificationScheduler;
 
   private static final String SENT_NOTIFICATION_COUNTER_NAME = name(PushNotificationManager.class, "sentPushNotification");
@@ -36,8 +36,8 @@ public class PushNotificationManager {
   private static final Logger logger = LoggerFactory.getLogger(PushNotificationManager.class);
 
   public PushNotificationManager(final AccountsManager accountsManager,
-      final APNSender apnSender,
-      final FcmSender fcmSender,
+      final PushNotificationSender apnSender,
+      final PushNotificationSender fcmSender,
       final PushNotificationScheduler pushNotificationScheduler) {
 
     this.accountsManager = accountsManager;

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationScheduler.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationScheduler.java
@@ -59,8 +59,8 @@ public class PushNotificationScheduler implements Managed {
   private static final String TOKEN_TYPE_TAG = "tokenType";
   private static final String ACCEPTED_TAG = "accepted";
 
-  private final APNSender apnSender;
-  private final FcmSender fcmSender;
+  private final PushNotificationSender apnSender;
+  private final PushNotificationSender fcmSender;
   private final AccountsManager accountsManager;
   private final FaultTolerantRedisClusterClient pushSchedulingCluster;
   private final Clock clock;
@@ -145,8 +145,8 @@ public class PushNotificationScheduler implements Managed {
   }
 
   public PushNotificationScheduler(final FaultTolerantRedisClusterClient pushSchedulingCluster,
-      final APNSender apnSender,
-      final FcmSender fcmSender,
+      final PushNotificationSender apnSender,
+      final PushNotificationSender fcmSender,
       final AccountsManager accountsManager,
       final int dedicatedProcessWorkerThreadCount,
       final int workerMaxConcurrency) throws IOException {
@@ -162,8 +162,8 @@ public class PushNotificationScheduler implements Managed {
 
   @VisibleForTesting
   PushNotificationScheduler(final FaultTolerantRedisClusterClient pushSchedulingCluster,
-                            final APNSender apnSender,
-                            final FcmSender fcmSender,
+                            final PushNotificationSender apnSender,
+                            final PushNotificationSender fcmSender,
                             final AccountsManager accountsManager,
                             final Clock clock,
                             final int dedicatedProcessThreadCount,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/InsecureStorageClient.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/InsecureStorageClient.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.securestorage;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class InsecureStorageClient implements StorageClient {
+  public InsecureStorageClient() {  }
+
+  public CompletableFuture<Void> deleteStoredData(final UUID accountUuid) {
+    return null;
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/InsecureStorageClient.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/InsecureStorageClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Signal Messenger, LLC
+ * Copyright 2025 Molly Instant Messenger
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/SecureStorageClient.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/SecureStorageClient.java
@@ -28,7 +28,7 @@ import org.whispersystems.textsecuregcm.util.HttpUtils;
 /**
  * A client for sending requests to Signal's secure storage service on behalf of authenticated users.
  */
-public class SecureStorageClient {
+public class SecureStorageClient implements StorageClient {
 
   private final ExternalServiceCredentialsGenerator storageServiceCredentialsGenerator;
   private final URI deleteUri;

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/StorageClient.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/StorageClient.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.securestorage;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface StorageClient {
+  CompletableFuture<Void> deleteStoredData(UUID accountUuid);
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/StorageClient.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securestorage/StorageClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Signal Messenger, LLC
+ * Copyright 2025 Molly Instant Messenger
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/InsecureValueRecovery2Client.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/InsecureValueRecovery2Client.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.securevaluerecovery;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class InsecureValueRecovery2Client implements ValueRecovery2Client {
+  public InsecureValueRecovery2Client(){};
+
+  public CompletableFuture<Void> deleteBackups(final UUID accountUuid) {
+    return null;
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/InsecureValueRecovery2Client.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/InsecureValueRecovery2Client.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Signal Messenger, LLC
+ * Copyright 2025 Molly Instant Messenger
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/SecureValueRecovery2Client.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/SecureValueRecovery2Client.java
@@ -7,6 +7,7 @@ package org.whispersystems.textsecuregcm.securevaluerecovery;
 
 import static org.whispersystems.textsecuregcm.util.HeaderUtils.basicAuthHeader;
 
+import com.google.api.client.util.Value;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HttpHeaders;
 import java.net.URI;
@@ -28,7 +29,7 @@ import org.whispersystems.textsecuregcm.util.HttpUtils;
 /**
  * A client for sending requests to Signal's secure value recovery v2 service on behalf of authenticated users.
  */
-public class SecureValueRecovery2Client {
+public class SecureValueRecovery2Client implements ValueRecovery2Client {
 
   private final ExternalServiceCredentialsGenerator secureValueRecoveryCredentialsGenerator;
   private final URI deleteUri;

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/ValueRecovery2Client.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/ValueRecovery2Client.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.securevaluerecovery;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface ValueRecovery2Client {
+  CompletableFuture<Void> deleteBackups(UUID accountUuid);
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/ValueRecovery2Client.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/securevaluerecovery/ValueRecovery2Client.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Signal Messenger, LLC
+ * Copyright 2025 Molly Instant Messenger
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 


### PR DESCRIPTION
This PR disables multiple features in the Whisper server in order to enable simpler local deployment during the development of the prototype. Some of those features may be reintroduced in a future stage of the development.

The complete list of features disabled is:
- Secure Value Recovery: The client class has been abstracted into an interface, which is implemented by the new `InsecureValueRecovery2Client` class. This new class does not actually call an SVR2 service to delete data.
- Secure Storage: The client class has been abstracted into an interface, which is implemented by the new `InsecureStorageClient` class. This new class does not actually call a secure storage service to delete data.
- Key Transparency: The key transparency controller has been disabled to remove the dependency on a key transparency service during development of the prototype.
- Notifications: The APN and FCM notification sender classes have been abstracted into an interface, which is implemented by the new `DummySender` class. This class simply logs notifications that would be sent to the server output to remove the dependencies on Apple and Firebase during development, until a final solution is in place.
- Payments: Functionality related to payment has been commented out in order to disable it in the prototype.